### PR TITLE
Mix Java and Scala

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -23,6 +23,7 @@
 
 """Rules for supporting the Scala language."""
 
+_jar_filetype = FileType([".jar"])
 _scala_filetype = FileType([".scala", ".java"])
 _srcjar_filetype = FileType([".srcjar"])
 # TODO is there a way to derive this from the above?
@@ -75,6 +76,20 @@ touch -t 198001010000 {manifest}
       progress_message="scala %s" % ctx.label,
       arguments=[])
 
+def _collect_plugin_paths(plugins):
+  paths = set()
+  for p in plugins:
+    if hasattr(p, "path"):
+      paths += [p.path]
+    elif hasattr(p, "scala"):
+      paths += [p.scala.outputs.jar.path]
+    elif hasattr(p, "java"):
+      paths += [j.class_jar.path for j in p.java.outputs.jars]
+    # support http_file pointed at a jar. http_jar uses ijar, which breaks scala macros
+    elif hasattr(p, "files"):
+      paths += [f.path for f in p.files]
+  return paths
+
 def _compile(ctx, _jars, dep_srcjars, buildijar):
   jars = _jars
   res_cmd = _add_resources_cmd(ctx)
@@ -88,12 +103,17 @@ def _compile(ctx, _jars, dep_srcjars, buildijar):
   sources = _scala_filetype.filter(ctx.files.srcs)
   srcjars = _srcjar_filetype.filter(ctx.files.srcs)
   all_srcjars = set(srcjars + list(dep_srcjars))
+  # look for any plugins:
+  plugins = _collect_plugin_paths(ctx.attr.plugins)
+  plugin_arg = ""
+  if (len(plugins) > 0):
+    plugin_arg = " ".join(["-Xplugin:%s" % p for p in plugins])
 
   # Set up the args to pass to scalac because they can be too long for bash
   scalac_args_file = ctx.new_file(ctx.outputs.jar, ctx.outputs.jar.short_path + "scalac_args")
-  scalac_args = """{scala_opts} {jvm_flags} -classpath "{jars}" -d {out}_tmp {files}""".format(
+  scalac_args = """{scala_opts} {plugin_arg} -classpath "{jars}" -d {out}_tmp {files}""".format(
       scala_opts=" ".join(ctx.attr.scalacopts),
-      jvm_flags=" ".join(["-J" + flag for flag in ctx.attr.jvm_flags]),
+      plugin_arg = plugin_arg,
       jars=":".join([j.path for j in jars]),
       files=" ".join([f.path for f in sources]),
       out=ctx.outputs.jar.path
@@ -115,24 +135,26 @@ unzip -o {srcjar} -d {{out}}_tmp_expand_srcjars >/dev/null
     srcjar_cmd += """find {out}_tmp_expand_srcjars -type f -name "*.scala" > {out}_args/files_from_jar\n"""
 
   cmd = """
-rm -rf {out}_tmp_expand_srcjars
-rm -rf {out}_tmp
-set -e
 rm -rf {out}_args
+rm -rf {out}_tmp
+rm -rf {out}_tmp_expand_srcjars
+set -e
 mkdir -p {out}_args
 touch {out}_args/files_from_jar
 mkdir -p {out}_tmp""" + srcjar_cmd + """
 cat {scalac_args} {out}_args/files_from_jar > {out}_args/args
-env JAVACMD={java} {scalac} @{out}_args/args
+env JAVACMD={java} {scalac} {jvm_flags} @{out}_args/args
 # Make jar file deterministic by setting the timestamp of files
 find {out}_tmp -exec touch -t 198001010000 {{}} \;
 touch -t 198001010000 {manifest}
 {jar} cmf {manifest} {out} -C {out}_tmp .
-rm -rf {out}_tmp_expand_srcjars
+rm -rf {out}_args
 rm -rf {out}_tmp
+rm -rf {out}_tmp_expand_srcjars
 """ + ijar_cmd + res_cmd
   cmd = cmd.format(
       java=ctx.file._java.path,
+      jvm_flags=" ".join(["-J" + flag for flag in ctx.attr.jvm_flags]),
       scalac=ctx.file._scalac.path,
       scalac_args=scalac_args_file.path,
       out=ctx.outputs.jar.path,
@@ -149,10 +171,15 @@ rm -rf {out}_tmp
           list(srcjars) +
           list(sources) +
           ctx.files.srcs +
+          ctx.files.plugins +
           ctx.files.resources +
           ctx.files._jdk +
           ctx.files._scalasdk +
-          [ctx.outputs.manifest, ctx.file._jar, ctx.file._ijar, scalac_args_file],
+          [ctx.outputs.manifest,
+            ctx.file._jar,
+            ctx.file._ijar,
+            ctx.file._scalac,
+            scalac_args_file],
       outputs=outs,
       command=cmd,
       progress_message="scala %s" % ctx.label,
@@ -351,6 +378,7 @@ _common_attrs = {
   "srcs": attr.label_list(
       allow_files=_scala_srcjar_filetype),
   "deps": attr.label_list(),
+  "plugins": attr.label_list(allow_files=_jar_filetype),
   "runtime_deps": attr.label_list(),
   "data": attr.label_list(allow_files=True, cfg=DATA_CFG),
   "resources": attr.label_list(allow_files=True),

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -23,11 +23,10 @@
 
 """Rules for supporting the Scala language."""
 
-_jar_filetype = FileType([".jar"])
-_scala_filetype = FileType([".scala"])
+_scala_filetype = FileType([".scala", ".java"])
 _srcjar_filetype = FileType([".srcjar"])
 # TODO is there a way to derive this from the above?
-_scala_srcjar_filetype = FileType([".scala", ".srcjar"])
+_scala_srcjar_filetype = FileType([".scala", ".java", ".srcjar"])
 
 def _adjust_resources_path(path):
   dir_1, dir_2, rel_path = path.partition("resources")
@@ -76,20 +75,6 @@ touch -t 198001010000 {manifest}
       progress_message="scala %s" % ctx.label,
       arguments=[])
 
-def _collect_plugin_paths(plugins):
-  paths = set()
-  for p in plugins:
-    if hasattr(p, "path"):
-      paths += [p.path]
-    elif hasattr(p, "scala"):
-      paths += [p.scala.outputs.jar.path]
-    elif hasattr(p, "java"):
-      paths += [j.class_jar.path for j in p.java.outputs.jars]
-    # support http_file pointed at a jar. http_jar uses ijar, which breaks scala macros
-    elif hasattr(p, "files"):
-      paths += [f.path for f in p.files]
-  return paths
-
 def _compile(ctx, _jars, dep_srcjars, buildijar):
   jars = _jars
   res_cmd = _add_resources_cmd(ctx)
@@ -103,17 +88,12 @@ def _compile(ctx, _jars, dep_srcjars, buildijar):
   sources = _scala_filetype.filter(ctx.files.srcs)
   srcjars = _srcjar_filetype.filter(ctx.files.srcs)
   all_srcjars = set(srcjars + list(dep_srcjars))
-  # look for any plugins:
-  plugins = _collect_plugin_paths(ctx.attr.plugins)
-  plugin_arg = ""
-  if (len(plugins) > 0):
-    plugin_arg = " ".join(["-Xplugin:%s" % p for p in plugins])
 
   # Set up the args to pass to scalac because they can be too long for bash
   scalac_args_file = ctx.new_file(ctx.outputs.jar, ctx.outputs.jar.short_path + "scalac_args")
-  scalac_args = """{scala_opts} {plugin_arg} -classpath "{jars}" -d {out}_tmp {files}""".format(
+  scalac_args = """{scala_opts} {jvm_flags} -classpath "{jars}" -d {out}_tmp {files}""".format(
       scala_opts=" ".join(ctx.attr.scalacopts),
-      plugin_arg = plugin_arg,
+      jvm_flags=" ".join(["-J" + flag for flag in ctx.attr.jvm_flags]),
       jars=":".join([j.path for j in jars]),
       files=" ".join([f.path for f in sources]),
       out=ctx.outputs.jar.path
@@ -135,26 +115,24 @@ unzip -o {srcjar} -d {{out}}_tmp_expand_srcjars >/dev/null
     srcjar_cmd += """find {out}_tmp_expand_srcjars -type f -name "*.scala" > {out}_args/files_from_jar\n"""
 
   cmd = """
-rm -rf {out}_args
-rm -rf {out}_tmp
 rm -rf {out}_tmp_expand_srcjars
+rm -rf {out}_tmp
 set -e
+rm -rf {out}_args
 mkdir -p {out}_args
 touch {out}_args/files_from_jar
 mkdir -p {out}_tmp""" + srcjar_cmd + """
 cat {scalac_args} {out}_args/files_from_jar > {out}_args/args
-env JAVACMD={java} {scalac} {jvm_flags} @{out}_args/args
+env JAVACMD={java} {scalac} @{out}_args/args
 # Make jar file deterministic by setting the timestamp of files
 find {out}_tmp -exec touch -t 198001010000 {{}} \;
 touch -t 198001010000 {manifest}
 {jar} cmf {manifest} {out} -C {out}_tmp .
-rm -rf {out}_args
-rm -rf {out}_tmp
 rm -rf {out}_tmp_expand_srcjars
+rm -rf {out}_tmp
 """ + ijar_cmd + res_cmd
   cmd = cmd.format(
       java=ctx.file._java.path,
-      jvm_flags=" ".join(["-J" + flag for flag in ctx.attr.jvm_flags]),
       scalac=ctx.file._scalac.path,
       scalac_args=scalac_args_file.path,
       out=ctx.outputs.jar.path,
@@ -171,15 +149,10 @@ rm -rf {out}_tmp_expand_srcjars
           list(srcjars) +
           list(sources) +
           ctx.files.srcs +
-          ctx.files.plugins +
           ctx.files.resources +
           ctx.files._jdk +
           ctx.files._scalasdk +
-          [ctx.outputs.manifest,
-            ctx.file._jar,
-            ctx.file._ijar,
-            ctx.file._scalac,
-            scalac_args_file],
+          [ctx.outputs.manifest, ctx.file._jar, ctx.file._ijar, scalac_args_file],
       outputs=outs,
       command=cmd,
       progress_message="scala %s" % ctx.label,
@@ -378,7 +351,6 @@ _common_attrs = {
   "srcs": attr.label_list(
       allow_files=_scala_srcjar_filetype),
   "deps": attr.label_list(),
-  "plugins": attr.label_list(allow_files=_jar_filetype),
   "runtime_deps": attr.label_list(),
   "data": attr.label_list(allow_files=True, cfg=DATA_CFG),
   "resources": attr.label_list(allow_files=True),


### PR DESCRIPTION
This is a bit of a hack: it allows every type of Scala target to contain Java files. Ideally this would be behind a flag and turned off (i.e. disallowed) by default.
